### PR TITLE
add rimraf as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "react-dom": "^16.11.0",
         "react-router-dom": "^5.1.2",
         "react-scripts": "^3.2.0",
+        "rimraf": "^3.0.0",
         "styled-components": "^4.4.1",
         "webpack-cli": "^3.3.10"
     },


### PR DESCRIPTION
Rimraf is required as part of the build pipeline but is not added as a dependency.